### PR TITLE
[Issue: #35] ゲーム画面レイアウト

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,9 +5,65 @@ body {
   height: 100vh;
   background-color: #f0f0f0;
   margin: 0;
+  font-family: Arial, sans-serif;
 }
 
-canvas {
+#game-container {
+  display: flex;
+  gap: 20px;
+}
+
+#left-container,
+#right-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 20px;
+}
+
+#hold-container,
+#next-container,
+#score-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#hold-canvas {
   background-color: #333;
   border: 2px solid #000;
+  width: 120px;
+  height: 120px;
+}
+
+.next-canvas {
+  background-color: #333;
+  border: 2px solid #000;
+  margin-bottom: 10px;
+}
+
+.next-canvas.large {
+  width: 120px;
+  height: 120px;
+}
+
+.next-canvas.small {
+  width: 80px;
+  height: 80px;
+}
+
+h3 {
+  margin-bottom: 10px;
+  color: #333;
+}
+
+#score-container {
+  text-align: center;
+}
+
+#score {
+  font-size: 24px;
+  font-weight: bold;
+  color: #333;
+  margin: 0;
 }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,31 @@
 <body>
     <!-- htmlのcanvas要素を使用 -->
     <!-- <canvas id="canvas" width="300" height="660"></canvas> -->
-    <canvas id="canvas"></canvas>
+    <div id="game-container">
+        <div id="left-container">
+            <div id="hold-container">
+                <h3>HOLD</h3>
+                <canvas id="hold-canvas"></canvas>
+            </div>
+        </div>
+        <div id="center-container">
+            <canvas id="canvas"></canvas>
+            <div id="score-container">
+                <h3>SCORE</h3>
+                <p id="score">0</p>
+            </div>
+        </div>
+        <div id="right-container">
+            <div id="next-container">
+                <h3>NEXT</h3>
+                <canvas id="next-canvas-1" class="next-canvas large"></canvas>
+                <canvas id="next-canvas-2" class="next-canvas small"></canvas>
+                <canvas id="next-canvas-3" class="next-canvas small"></canvas>
+                <canvas id="next-canvas-4" class="next-canvas small"></canvas>
+                <canvas id="next-canvas-5" class="next-canvas small"></canvas>
+            </div>
+        </div>
+    </div>
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,6 @@
 import { PLAY_SCREEN_WIDTH, PLAY_SCREEN_HEIGHT, DROP_SPEED } from './utils.js';
 import { initField, field, clearFullLines } from './board.js';
-import { addNewTetrimino, moveTetrimino, lockTetrimino, getNextTetrimino, holdTetrimino, setCurrentTetrimino, getCurrentTetrimino, hold, setInitialHoldTetrimino } from './tetrimino.js';
+import { addNewTetrimino, moveTetrimino, lockTetrimino, getNextTetrimino, holdTetrimino, setCurrentTetrimino, getCurrentTetrimino, hold, } from './tetrimino.js';
 import { drawPlayScreen, drawHoldTetrimino, drawNextTetriminos } from './renderer.js';
 import { checkGameOver, handleGameOver } from './score.js';
 
@@ -10,7 +10,7 @@ let nextTetriminos = [];
 
 export function initGame() {
     initField();
-    setInitialHoldTetrimino(); // 初期holdテトリミノを設定
+
     for (let i = 0; i < 5; i++) {
         nextTetriminos.push(getNextTetrimino());
     }
@@ -47,12 +47,3 @@ function normalDrop(currentTime) {
     }
 }
 
-export function handleHold() {
-    const heldTetrimino = hold();
-    if (heldTetrimino) {
-        setCurrentTetrimino(heldTetrimino);
-    } else {
-        setCurrentTetrimino(nextTetriminos.shift());
-        nextTetriminos.push(getNextTetrimino());
-    }
-}

--- a/js/game.js
+++ b/js/game.js
@@ -1,20 +1,31 @@
 import { PLAY_SCREEN_WIDTH, PLAY_SCREEN_HEIGHT, DROP_SPEED } from './utils.js';
 import { initField, field, clearFullLines } from './board.js';
-import { currentTetrimino, addNewTetrimino, moveTetrimino, lockTetrimino } from './tetrimino.js';
-import { drawPlayScreen } from './renderer.js';
+import { addNewTetrimino, moveTetrimino, lockTetrimino, getNextTetrimino, holdTetrimino, setCurrentTetrimino, getCurrentTetrimino, hold, setInitialHoldTetrimino } from './tetrimino.js';
+import { drawPlayScreen, drawHoldTetrimino, drawNextTetriminos } from './renderer.js';
 import { checkGameOver, handleGameOver } from './score.js';
 
 export let animationId;
 let lastDropTime = 0;
+let nextTetriminos = [];
 
 export function initGame() {
     initField();
+    setInitialHoldTetrimino(); // 初期holdテトリミノを設定
+    for (let i = 0; i < 5; i++) {
+        nextTetriminos.push(getNextTetrimino());
+    }
+    setCurrentTetrimino(nextTetriminos.shift());
+    nextTetriminos.push(getNextTetrimino());
 }
 
 export function gameLoop(currentTime) {
     drawPlayScreen();
-    if (currentTetrimino === null) {
-        addNewTetrimino();
+    drawHoldTetrimino(holdTetrimino);
+    drawNextTetriminos(nextTetriminos);
+    
+    if (getCurrentTetrimino() === null) {
+        setCurrentTetrimino(nextTetriminos.shift());
+        nextTetriminos.push(getNextTetrimino());
         if (checkGameOver()) {
             handleGameOver();
             return;
@@ -25,12 +36,23 @@ export function gameLoop(currentTime) {
     }
     animationId = requestAnimationFrame(gameLoop);
 }
-
 function normalDrop(currentTime) {
     if (currentTime - lastDropTime > DROP_SPEED) {
+        const currentTetrimino = getCurrentTetrimino();
         if (!moveTetrimino(currentTetrimino.row + 1, currentTetrimino.column)) {
             lockTetrimino();
+            setCurrentTetrimino(null);
         }
         lastDropTime = currentTime;
+    }
+}
+
+export function handleHold() {
+    const heldTetrimino = hold();
+    if (heldTetrimino) {
+        setCurrentTetrimino(heldTetrimino);
+    } else {
+        setCurrentTetrimino(nextTetriminos.shift());
+        nextTetriminos.push(getNextTetrimino());
     }
 }

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -1,11 +1,30 @@
 import { BLOCK_SIZE, CANVAS_WIDTH, CANVAS_HEIGHT, PLAY_SCREEN_HEIGHT, PLAY_SCREEN_WIDTH } from './utils.js';
 import { field } from './board.js';
-import { currentTetrimino, getTetriminoDropPosition, ghostTetriminoRow } from './tetrimino.js';
+import { getCurrentTetrimino, getTetriminoDropPosition, ghostTetriminoRow } from './tetrimino.js';
 
 const canvas = document.getElementById('canvas');
+const holdCanvas = document.querySelector('#hold-canvas');
+const nextCanvases = [
+    document.querySelector('#next-canvas-1'),
+    document.querySelector('#next-canvas-2'),
+    document.querySelector('#next-canvas-3'),
+    document.querySelector('#next-canvas-4'),
+    document.querySelector('#next-canvas-5')
+];
+
 const ctx = canvas.getContext('2d');
+const holdCtx = holdCanvas.getContext('2d');
+const nextCtxs = nextCanvases.map(canvas => canvas.getContext('2d'));
+
 canvas.width = CANVAS_WIDTH;
 canvas.height = CANVAS_HEIGHT;
+
+// Hold と Next キャンバスのサイズを設定（例として4x4のグリッドとします）
+const SIDE_CANVAS_SIZE = BLOCK_SIZE * 4;
+holdCanvas.width = holdCanvas.height = SIDE_CANVAS_SIZE;
+nextCanvases.forEach(canvas => {
+    canvas.width = canvas.height = SIDE_CANVAS_SIZE;
+});
 
 export function drawPlayScreen() {
     ctx.fillStyle = '#000';
@@ -20,6 +39,7 @@ export function drawPlayScreen() {
     }
 
     drawGrid();
+    const currentTetrimino = getCurrentTetrimino();
     if (currentTetrimino) {
         drawTetrimino(currentTetrimino);
         getTetriminoDropPosition();
@@ -49,6 +69,44 @@ function drawTetrimino(tetrimino) {
         rowShape.forEach((cell, c) => {
             if (cell) {
                 drawBlock(column + c, row + r, color);
+            }
+        });
+    });
+}
+
+export function drawHoldTetrimino(holdTetrimino) {
+    clearCanvas(holdCtx, SIDE_CANVAS_SIZE);
+    if (holdTetrimino) {
+        drawTetriminoOnCanvas(holdCtx, holdTetrimino, SIDE_CANVAS_SIZE / 2, SIDE_CANVAS_SIZE / 2);
+    }
+}
+
+export function drawNextTetriminos(nextTetriminos) {
+    nextCtxs.forEach((ctx, index) => {
+        clearCanvas(ctx, SIDE_CANVAS_SIZE);
+        if (nextTetriminos[index]) {
+            drawTetriminoOnCanvas(ctx, nextTetriminos[index], SIDE_CANVAS_SIZE / 2, SIDE_CANVAS_SIZE / 2);
+        }
+    });
+}
+
+function clearCanvas(ctx, size) {
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, size, size);
+}
+
+function drawTetriminoOnCanvas(ctx, tetrimino, centerX, centerY) {
+    const { shape, color } = tetrimino;
+    const blockSize = Math.min(centerX, centerY) / 3; // テトリミノのサイズを調整
+    const offsetX = centerX - (shape[0].length * blockSize) / 2;
+    const offsetY = centerY - (shape.length * blockSize) / 2;
+
+    ctx.fillStyle = color;
+    shape.forEach((row, y) => {
+        row.forEach((value, x) => {
+            if (value) {
+                ctx.fillRect(offsetX + x * blockSize, offsetY + y * blockSize, blockSize, blockSize);
+                ctx.strokeRect(offsetX + x * blockSize, offsetY + y * blockSize, blockSize, blockSize);
             }
         });
     });

--- a/js/score.js
+++ b/js/score.js
@@ -1,4 +1,4 @@
-import { currentTetrimino } from './tetrimino.js';
+import { getCurrentTetrimino } from './tetrimino.js';
 import { field } from './board.js';
 import { animationId } from './game.js';
 import { PLAY_SCREEN_WIDTH } from './utils.js';
@@ -6,6 +6,7 @@ import { PLAY_SCREEN_WIDTH } from './utils.js';
 export let isGameOver = false;
 
 export function checkGameOver() {
+    const currentTetrimino = getCurrentTetrimino();
     if (!currentTetrimino) {
         console.log("Not Null");
         return false;

--- a/js/tetrimino.js
+++ b/js/tetrimino.js
@@ -12,11 +12,6 @@ export function setCurrentTetrimino(tetrimino) {
     currentTetrimino = tetrimino;
 }
 
-export function setInitialHoldTetrimino() {
-    if (holdTetrimino === null) {
-        holdTetrimino = getNextTetrimino();
-    }
-}
 
 export function getCurrentTetrimino() {
     return currentTetrimino;

--- a/js/tetrimino.js
+++ b/js/tetrimino.js
@@ -1,11 +1,27 @@
 import { TETRIMINOS, PLAY_SCREEN_HEIGHT, PLAY_SCREEN_WIDTH } from './utils.js';
 import { field, checkCollision, clearFullLines } from './board.js';
 
-export let currentTetrimino = null;
+let currentTetrimino = null;
 export let ghostTetriminoRow = null;
 export let holdTetrimino = null;
 export let holdCount = 0;
 let tetriminoSequence = [];
+
+
+export function setCurrentTetrimino(tetrimino) {
+    currentTetrimino = tetrimino;
+}
+
+export function setInitialHoldTetrimino() {
+    if (holdTetrimino === null) {
+        holdTetrimino = getNextTetrimino();
+    }
+}
+
+export function getCurrentTetrimino() {
+    return currentTetrimino;
+}
+
 
 export function getNextTetrimino() {
     if (tetriminoSequence.length === 0) {
@@ -45,6 +61,7 @@ export function moveTetrimino(newRow, newColumn, newShape = null) {
     return true;
 }
 
+
 // テトリミノの移動操作
 export const moveLeft = () => moveTetrimino(currentTetrimino.row, currentTetrimino.column - 1);
 export const moveRight = () => moveTetrimino(currentTetrimino.row, currentTetrimino.column + 1);
@@ -70,24 +87,21 @@ export function hold() {
     if (holdTetrimino === null) {
         holdTetrimino = { ...currentTetrimino };
         currentTetrimino = null;
-        holdCount++
+        holdCount++;
     } else if (holdCount === 0) {
         let tempTetrimino = { ...holdTetrimino };
         holdTetrimino = { ...currentTetrimino };
 
-        // ホールド入れ替え後は初期位置、初期向きから生成
-        const {column, row} = getInitialTetriminoPosition(currentTetrimino.shape);
-        Object.assign(currentTetrimino, {
-            shape: tempTetrimino.shape,
-            name: tempTetrimino.name,
-            color: tempTetrimino.color,
+        const {column, row} = getInitialTetriminoPosition(tempTetrimino.shape);
+        currentTetrimino = {
+            ...tempTetrimino,
             column: column,
             row: row,
-        });
-        // holdCountを+する
+        };
         holdCount++;
     }
 }
+
 
 function resetHoldCount() {
     holdCount = 0;

--- a/js/tetrimino.js
+++ b/js/tetrimino.js
@@ -86,6 +86,8 @@ export function hold() {
     } else if (holdCount === 0) {
         let tempTetrimino = { ...holdTetrimino };
         holdTetrimino = { ...currentTetrimino };
+        // 初期ホールドのみ機能しない
+        holdTetrimino.shape =  TETRIMINOS[holdTetrimino.name].shape;    
 
         const {column, row} = getInitialTetriminoPosition(tempTetrimino.shape);
         currentTetrimino = {


### PR DESCRIPTION
## 概要
ゲーム画面上にHoldキャンバス、NEXTキャンバス、SCORE表示をできるようにする。
※SCOREロジックは未実装。

## 変更内容

1.`index.html`の更新。

2.`style.css`の更新。

3.`renderer.js` の更新。

- hold と next のキャンバス要素を取得し、2D コンテキストを準備。
- キャンバスのサイズを設定（SIDE_CANVAS_SIZE = BLOCK_SIZE * 4）。
- `drawHoldTetrimino` と `drawNextTetriminos` 関数を追加。
- `clearCanvas` と `drawTetriminoOnCanvas `ヘルパー関数を追加。

4.`tetrimino.js`の更新。

- ` holdTetrimino` 変数を追加。
- `hold` 関数を実装して、現在のテトリミノと hold テトリミノを交換。
- `setInitialHoldTetrimino` 関数を追加して、ゲーム開始時に hold テトリミノを設定。
  `setInitialHoldTetrimino`がないとゲーム開始時にHOLDキャンバス内にミノが表示されない。

5.`game.js `の更新。

- `nextTetriminos` 配列を追加して、次の 5 つのテトリミノを保持。

- ` initGame` 関数を更新して、初期の next テトリミノと hold テトリミノを設定。

- `gameLoop` 関数を更新して、hold と next のテトリミノを描画。
- `handleHold` 関数を追加して、hold 操作を処理。

6.その他

- currentTetrimino の参照方法を変更（直接参照から getCurrentTetrimino() 関数を使用）。
 


## テスト結果

- HOLDを実行することで、HOLD canvasに表示されているテトリミノが更新される。
- テトリミノを落下させ固定されると、NEXT canvas内のテトリミノが更新される。
- NEXT canvas内のテトリミノは、次に操作するテトリミノを前もって確認できる。

![画面レイアウト](https://github.com/user-attachments/assets/90fe316e-b3ef-420f-8165-afaa03459127)


## 関連Issue
Closes #35 