### PR TITLE
[Issue: #44] スタート画面の追加とゲームスタート、ゲームやり直しの機能を実装。

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,6 +8,23 @@ body {
   font-family: Arial, sans-serif;
 }
 
+#start-screen {
+  text-align: center;
+  padding: 20px;
+}
+
+#start-button {
+  font-size: 1.5em;
+  padding: 10px 20px;
+  margin: 20px 0;
+}
+
+#controls {
+  max-width: 300px;
+  margin: 0 auto;
+  text-align: left;
+}
+
 #game-container {
   display: flex;
   gap: 20px;

--- a/index.html
+++ b/index.html
@@ -7,33 +7,51 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <!-- htmlのcanvas要素を使用 -->
-    <!-- <canvas id="canvas" width="300" height="660"></canvas> -->
-    <div id="game-container">
-        <div id="left-container">
-            <div id="hold-container">
-                <h3>HOLD</h3>
-                <canvas id="hold-canvas"></canvas>
-            </div>
-        </div>
-        <div id="center-container">
-            <canvas id="canvas"></canvas>
-            <div id="score-container">
-                <h3>SCORE</h3>
-                <p id="score">0</p>
-            </div>
-        </div>
-        <div id="right-container">
-            <div id="next-container">
-                <h3>NEXT</h3>
-                <canvas id="next-canvas-1" class="next-canvas large"></canvas>
-                <canvas id="next-canvas-2" class="next-canvas small"></canvas>
-                <canvas id="next-canvas-3" class="next-canvas small"></canvas>
-                <canvas id="next-canvas-4" class="next-canvas small"></canvas>
-                <canvas id="next-canvas-5" class="next-canvas small"></canvas>
-            </div>
+    <div id="start-screen">
+        <h1>テトリス</h1>
+        <button id="start-button">ゲーム開始</button>
+        <div id="controls">
+            <h2>操作方法</h2>
+            <ul>
+                <li>← → : 左右移動</li>
+                <li>↓ : 落下加速 (ソフトドロップ)</li>
+                <li>↑ or X: 時計回りに回転</li>
+                <li>Z : 反時計回りに回転</li>
+                <li>スペース : ハードドロップ</li>
+                <li>C or shift: ホールド</li>
+            </ul>
         </div>
     </div>
+
+
+    <div id="game-screen" style="display: none;">
+        <button id="home-button">ホームに戻る</button>
+        <div id="game-container">
+            <div id="left-container">
+                <div id="hold-container">
+                    <h3>HOLD</h3>
+                    <canvas id="hold-canvas"></canvas>
+                </div>
+            </div>
+            <div id="center-container">
+                <canvas id="canvas"></canvas>
+                <div id="score-container">
+                    <h3>SCORE</h3>
+                    <p id="score">0</p>
+                </div>
+            </div>
+            <div id="right-container">
+                <div id="next-container">
+                    <h3>NEXT</h3>
+                    <canvas id="next-canvas-1" class="next-canvas large"></canvas>
+                    <canvas id="next-canvas-2" class="next-canvas small"></canvas>
+                    <canvas id="next-canvas-3" class="next-canvas small"></canvas>
+                    <canvas id="next-canvas-4" class="next-canvas small"></canvas>
+                    <canvas id="next-canvas-5" class="next-canvas small"></canvas>
+                </div>
+            </div>
+        </div>   
+    </div>    
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/js/game.js
+++ b/js/game.js
@@ -44,6 +44,12 @@ export async function gameLoop(currentTime) {
     animationId = requestAnimationFrame(gameLoop);
 }
 
+// アニメーションを停止する関数
+export function stopGameLoop() {
+    // requestAnimationFrameを止めるメソッド
+    cancelAnimationFrame(animationId);
+}
+
 async function normalDrop(currentTime) {
     if (currentTime - lastDropTime > DROP_SPEED) {
         moveTetrimino(currentTetrimino.row + 1, currentTetrimino.column);

--- a/js/game.js
+++ b/js/game.js
@@ -1,6 +1,6 @@
 import { DROP_SPEED } from './utils.js';
 import { initField,} from './board.js';
-import { isLocking, moveTetrimino, canMoveTetrimino, lockTetrimino, getNextTetrimino, holdTetrimino, setCurrentTetrimino, currentTetrimino, setIsLocking,} from './tetrimino.js';
+import { isLocking, moveTetrimino, canMoveTetrimino, lockTetrimino, getNextTetrimino, holdTetrimino, setCurrentTetrimino, currentTetrimino, setIsLocking, initHold} from './tetrimino.js';
 import { drawPlayScreen, drawHoldTetrimino, drawNextTetriminos } from './renderer.js';
 import { checkGameOver, handleGameOver } from './score.js';
 
@@ -10,7 +10,13 @@ let nextTetriminos = [];
 
 export function initGame() {
     initField();
+    initHold();
+    initNext();
+    // initScore();
+}
 
+export function initNext(){
+    nextTetriminos = [];
     for (let i = 0; i < 5; i++) {
         nextTetriminos.push(getNextTetrimino());
     }

--- a/js/gameManager.js
+++ b/js/gameManager.js
@@ -1,0 +1,21 @@
+// ゲームスタート、ゲームやり直しの関数
+export function setupGameScreens(startGameFunction, stopGameFunction,) {
+    const startScreen = document.getElementById('start-screen');
+    const gameScreen = document.getElementById('game-screen');
+    const startButton = document.getElementById('start-button');
+    const homeButton = document.getElementById('home-button');
+
+    
+
+    startButton.addEventListener('click', () => {
+        startScreen.style.display = 'none';
+        gameScreen.style.display = 'block';
+        startGameFunction(); // ゲームを開始
+    });
+
+    homeButton.addEventListener('click', () => {
+        gameScreen.style.display = 'none';
+        startScreen.style.display = 'block';
+        stopGameFunction(); // ゲームを停止・リセット
+    });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,16 @@
-// main.js
-import { initGame, gameLoop } from './game.js';
+import { initGame, gameLoop, stopGameLoop } from './game.js';
 import { initInput } from './input.js';
+import { setupGameScreens } from './gameManager.js';
 
-function init() {
+// スタートボタンを押すことで実行される関数の集まり。
+function startGame() {
     initGame();
     initInput();
-    requestAnimationFrame(gameLoop);
+    gameLoop();
+}
+
+function init() {
+    setupGameScreens(startGame, stopGameLoop,);
 }
 
 init();

--- a/js/tetrimino.js
+++ b/js/tetrimino.js
@@ -8,6 +8,10 @@ export let holdCount = 0;
 export let isLocking = false;
 let tetriminoSequence = [];
 
+export function initHold(){
+    holdTetrimino = null;
+    holdCount = 0;
+}
 
 export function setCurrentTetrimino(tetrimino) {
     currentTetrimino = tetrimino;


### PR DESCRIPTION
## 概要
スタート画面の追加とゲーム開始、やり直し機能を実装。

## 変更内容

- `index.html`内にゲーム開始画面を追加。主にスタートボタンとキーボード操作の説明を追加。
- 追加した`html`に応じて`css`を追加。
- `ゲーム開始`ボタンを押すことでゲームを開始し、ゲーム画面の`ホームに戻る`ボタンでゲームをやり直しスタート画面へ戻ることができる。
- `gameManager.js`ファイルを追加し、このファイルにゲーム管理をするためのロジックを追加。
- `game.js`にアニメーションを停止する`stopGameLoop()`を追加。
- `main.js`の`init()`を修正。修正前の`init()`内に`setupGameScreens()`を追加するだけだとスタート画面から裏でゲームが始まり、ゲーム画面からスタート画面へ戻る際も裏でゲームが実行され続けるため、`init()`内に`setupGameScreens(startGame, stopGameLoop);`のみを追加し、`startGame()`内に修正前の`init()`内にあった関数を追加した。この追加により、ボタンをクリックすることでゲーム開始、ゲームやり直し(スタート画面へ戻る)を正しく実行できるようになり、正常にゲームが動作するようになる。

## テスト結果

![画面収録 2024-09-25 15 45 17](https://github.com/user-attachments/assets/b74c2663-d7d4-4eb9-9651-eb4f4a3015f0)




## 関連Issue
Closes #44 