### PR TITLE
[Issue: #48] ゲーム画面のレイアウト

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -155,11 +155,15 @@ h3 {
 }
 
 #home-button {
+  all: unset; /* 全てのデフォルトスタイルをリセット */
+}
+
+i {
   cursor: pointer;
   transition: all 0.4s ease;
 }
 
-#home-button:hover {
+i:hover {
   opacity: 0.5;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,8 @@ body {
 }
 
 canvas {
-  border: 2px solid rgba(173, 216, 230, 0.2);
+  border: solid 3px #6091d3; /*線*/
+  border-radius: 10px; /*角の丸み*/
   background-color: rgba(10, 25, 47, 0.7);
   box-shadow: 0 0 20px rgba(173, 216, 230, 0.3);
 }
@@ -115,6 +116,19 @@ h3 {
   flex-direction: column;
   align-items: center;
   color: white;
+}
+
+#score-container div {
+  margin-top: 15px;
+  padding-right: 8px;
+  padding-left: 8px;
+  border: solid 3px #6091d3; /*線*/
+  border-radius: 10px; /*角の丸み*/
+  box-shadow: 0 0 20px rgba(173, 216, 230, 0.3);
+}
+
+#score-container #score {
+  margin-bottom: 10px;
 }
 
 #hold-canvas {

--- a/css/style.css
+++ b/css/style.css
@@ -137,13 +137,17 @@ h3 {
 }
 
 #controls {
-  /* display: flex; */
-  height: 100%;
+  margin-top: 50px;
 }
 
-#controls button {
-  /* display: block; */
-  height: 50;
+#home-button {
+  cursor: pointer;
+  transition: all 0.4s ease;
+}
+
+#home-button:hover {
+  opacity: 0.5;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
 #score-container {

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tetris</title>
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body>
     <div id="space-background">
@@ -40,6 +41,11 @@
                         <p id="score">0</p>
                         <h3>LEVEL</h3>
                         <p id="level">1</p>
+                        <h3>LINES</h3>
+                        <p id="line">0</p>
+                    </div>
+                    <div id="controls">
+                       <i id="home-button" class="fa-solid fa-house fa-2x"></i>
                     </div>
                 </div>
             </div>
@@ -55,9 +61,6 @@
                     <canvas id="next-canvas-4" class="next-canvas small"></canvas>
                     <canvas id="next-canvas-5" class="next-canvas small"></canvas>
                 </div>
-            </div>
-            <div id="controls">
-                <button id="home-button">ホームに戻る</button>
             </div>
         </div>   
     </div>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
                         </div>
                     </div>
                     <div id="controls">
-                       <i id="home-button" class="fa-solid fa-house fa-2x"></i>
+                       <button id="home-button"><i class="fa-solid fa-house fa-2x"></i></button>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -37,12 +37,18 @@
                     <h3>HOLD</h3>
                     <canvas id="hold-canvas"></canvas>
                     <div id="score-container">
-                        <h3>SCORE</h3>
-                        <p id="score">0</p>
-                        <h3>LEVEL</h3>
-                        <p id="level">1</p>
-                        <h3>LINES</h3>
-                        <p id="line">0</p>
+                        <div>
+                            <h3>SCORE</h3>
+                            <p id="score">0</p>
+                        </div>
+                        <div>
+                            <h3>LEVEL</h3>
+                            <p id="level">1</p>
+                        </div>
+                        <div>
+                            <h3>LINES</h3>
+                            <p id="line">0</p>
+                        </div>
                     </div>
                     <div id="controls">
                        <i id="home-button" class="fa-solid fa-house fa-2x"></i>

--- a/js/game.js
+++ b/js/game.js
@@ -3,7 +3,7 @@ import { DROP_SPEED } from './utils.js';
 import { initField,clearFullLines} from './board.js';
 import { isLocking, moveTetrimino, canMoveTetrimino, lockTetrimino, getNextTetrimino, holdTetrimino, setCurrentTetrimino, currentTetrimino, setIsLocking, initHold} from './tetrimino.js';
 import { drawPlayScreen, drawHoldTetrimino, drawNextTetriminos } from './renderer.js';
-import { checkGameOver, handleGameOver, updateScore } from './score.js';
+import { checkGameOver, handleGameOver, updateScore, initScore, initLines, initLevel } from './score.js';
 
 export let animationId;
 let lastDropTime = 0;
@@ -13,7 +13,9 @@ export function initGame() {
     initField();
     initHold();
     initNext();
-    // initScore();
+    initScore();
+    initLevel();
+    initLines();
 }
 
 export function initNext(){

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -17,11 +17,9 @@ const ctx = canvas.getContext('2d');
 
 // Holdキャンバス
 const holdCtx = holdCanvas.getContext('2d');
-// holdCtx.fillStyle = 'rgba(10, 25, 47, 0.7)';　一旦保留
 
 // Nextキャンバス
 const nextCtxs = nextCanvases.map(canvas => canvas.getContext('2d'));
-// nextCtxs.fillStyle = 'rgba(10, 25, 47, 0.7)';　一旦保留
 
 canvas.width = CANVAS_WIDTH;
 canvas.height = CANVAS_HEIGHT;
@@ -107,7 +105,7 @@ export function drawNextTetriminos(nextTetriminos) {
 }
 
 function clearCanvas(ctx, size) {
-    ctx.fillStyle = '#000';
+    ctx.fillStyle = 'rgba(10, 25, 47, 0.7)';
     ctx.fillRect(0, 0, size, size);
 }
 

--- a/js/score.js
+++ b/js/score.js
@@ -7,6 +7,8 @@ let score = 0;
 let level = 1;
 let linesCleared = 0;
 
+let scoreElement = document.getElementById('score');
+let levelElement = document.getElementById('level');
 let line = document.querySelector("#line");
 
 export let isGameOver = false;
@@ -18,6 +20,21 @@ export function getScore() {
 export function getLevel() {
     return level;
 }
+
+export function initScore(){
+    score = 0;
+    scoreElement.textContent = score;
+};
+
+export function initLevel(){
+    level = 1;
+    levelElement.textContent = level;
+}
+
+export function initLines(){
+        linesCleared = 0;
+        line.textContent = linesCleared
+};
 
 export function updateScore(clearedLines) {
     if (clearedLines === 0) {
@@ -57,14 +74,12 @@ function checkLevelUp() {
 }
 
 function updateScoreDisplay() {
-    const scoreElement = document.getElementById('score');
     if (scoreElement) {
         scoreElement.textContent = score;
     }
 }
 
 function updateLevelDisplay() {
-    const levelElement = document.getElementById('level');
     if (levelElement) {
         levelElement.textContent = level;
     }

--- a/js/score.js
+++ b/js/score.js
@@ -7,6 +7,8 @@ let score = 0;
 let level = 1;
 let linesCleared = 0;
 
+let line = document.querySelector("#line");
+
 export let isGameOver = false;
 
 export function getScore() {
@@ -25,6 +27,7 @@ export function updateScore(clearedLines) {
     const scoreIncrement = calculateScoreIncrement(clearedLines);
     score += scoreIncrement;
     linesCleared += clearedLines;
+    line.textContent = linesCleared //消したライン数をゲーム画面で表示
 
     checkLevelUp();
     updateScoreDisplay();


### PR DESCRIPTION
## 概要
ゲーム画面のレイアウトを変更

## 変更内容

1. ホームへ戻るボタンの位置調整とアイコン化
2. ゲーム画面のborderをスタイリング
3. LINESのゲーム画面への表示ロジックを追加
4. ゲーム初期化する`initScore()`,`initLevel()`,`initLines()`を`initGame()`内に追記
5. buttonタグのデフォルトスタイルをリセット
6. HOLD,NEXTキャンバス内のカラーをゲームフィールド内のカラーに統一

## テスト結果
![canvas-navy](https://github.com/user-attachments/assets/f6f7e9d7-021c-4e77-8a94-0be39e2f2d3d)


## レビューポイント
特に`initGame()`内に追記した関数が冗長かどうかレビューしてほしいです。

## 関連Issue
※ 今回使ったブランチはまた使うかもしれないので削除せず残したままでお願いします。

#48 