### PR TITLE
[Issue: #48]スタート画面のタイトル、PLAYボタンのスタイリング、モーダルウィンドウの追加

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,19 +19,6 @@ h3 {
   margin-bottom: 10px;
 }
 
-.planet {
-  position: absolute;
-  width: 800px;
-  height: 800px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #1c3a6e 0%, #0a1930 70%);
-  box-shadow: inset 0 0 50px rgba(173, 216, 230, 0.2);
-  z-index: 0;
-  top: 50%;
-  left: 70%;
-  transform: translate(-50%, -50%);
-}
-
 /* 新しい宇宙テーマの背景のスタイル */
 #space-background {
   position: fixed;
@@ -44,7 +31,107 @@ h3 {
   background: linear-gradient(135deg, #0a192f, #20314f);
 }
 
-.stars {
+.planet {
+  position: absolute;
+  width: 800px;
+  height: 800px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #1c3a6e 0%, #0a1930 70%);
+  box-shadow: inset 0 0 50px rgba(173, 216, 230, 0.2);
+  z-index: 0;
+  top: 50%;
+  left: 70%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.button-container {
+  position: absolute;
+  top: 100px;
+  right: 300px;
+}
+
+#control-btn {
+  font-size: 1.8rem;
+  color: greenyellow;
+  cursor: pointer;
+}
+
+#control-btn:hover i {
+  color: green;
+  transition: all 0.4s ease;
+}
+
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(5px);
+}
+
+.modal-content {
+  background: rgba(0, 0, 0, 0.8);
+  border-radius: 15px;
+  padding: 20px;
+  width: 300px;
+  box-shadow: 0 0 20px rgba(0, 255, 0, 0.2);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-height: 80vh; /* ビューポートの高さの80%に制限 */
+  overflow-y: auto; /* 内容が多い場合にスクロール可能に */
+}
+
+.controls-title {
+  text-align: center;
+  color: #00ff00;
+  font-size: 24px;
+  margin-bottom: 20px;
+}
+
+.control-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 15px;
+  padding: 10px 0;
+}
+
+.control-icon {
+  color: #e0e0ff;
+  width: 40px;
+  height: 40px;
+  background: rgba(0, 255, 0, 0.2);
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 15px;
+  min-width: 40px;
+}
+
+.control-description {
+  flex-grow: 1;
+  color: #e0e0ff;
+}
+
+.close-btn {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+}
+.close-btn:hover {
+  color: #00ff00;
+}
+
+.star {
   z-index: -1;
   position: absolute;
   width: 100%;
@@ -57,7 +144,8 @@ h3 {
     radial-gradient(white, rgba(255, 255, 255, 0.15) 1px, transparent 30px),
     radial-gradient(white, rgba(255, 255, 255, 0.1) 2px, transparent 40px);
   background-size: 550px 550px, 350px 350px, 250px 250px;
-  animation: twinkle 60s infinite linear;
+  background-repeat: repeat, repeat, repeat; /* starがループ */
+  animation: twinkle 55s infinite linear;
 }
 
 @keyframes twinkle {
@@ -76,16 +164,144 @@ h3 {
   z-index: 1;
 }
 
-#start-button {
-  font-size: 1.5em;
-  padding: 10px 20px;
-  margin: 20px 0;
+/* スタート画面のタイトルスタイル */
+.tetris-title {
+  font-size: 6rem;
+  font-weight: 900;
+  color: #ffffff;
+  text-transform: uppercase;
+  letter-spacing: 0.5rem;
+  text-shadow: 3px 3px 0px #00ffff, -3px -3px 0px #ff00ff,
+    0 0 10px rgba(255, 255, 255, 0.8), 0 0 20px rgba(255, 255, 255, 0.5),
+    0 0 30px rgba(255, 255, 255, 0.3);
+  background: linear-gradient(45deg, #00ffff, #ff00ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  position: relative;
+  animation: pulse 3s infinite alternate;
+}
+.tetris-title::before {
+  content: attr(data-text);
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: -1;
+  background: linear-gradient(45deg, #ff00ff, #00ffff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  opacity: 0.5;
+  filter: blur(1px);
+}
+.tetris-title::after {
+  content: attr(data-text);
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: -2;
+  color: #ffffff;
+  opacity: 0.1;
+  filter: blur(3px);
+}
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1.05);
+  }
 }
 
-#key-rule {
-  max-width: 300px;
+/* スタート画面のボタンスタイル */
+
+.animated-button {
   margin: 0 auto;
-  text-align: left;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 16px 36px;
+  border: 4px solid;
+  border-color: transparent;
+  font-size: 16px;
+  background-color: inherit;
+  border-radius: 100px;
+  font-weight: 600;
+  color: greenyellow;
+  box-shadow: 0 0 0 2px greenyellow;
+  cursor: pointer;
+  overflow: hidden;
+  transition: all 0.6s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.animated-button svg {
+  position: absolute;
+  width: 24px;
+  fill: greenyellow;
+  z-index: 9;
+  transition: all 0.8s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.animated-button .arr-1 {
+  right: 16px;
+}
+
+.animated-button .arr-2 {
+  left: -25%;
+}
+
+.animated-button .circle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 20px;
+  height: 20px;
+  background-color: greenyellow;
+  border-radius: 50%;
+  opacity: 0;
+  transition: all 0.8s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.animated-button .text {
+  position: relative;
+  z-index: 1;
+  transform: translateX(-12px);
+  transition: all 0.8s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.animated-button:hover {
+  box-shadow: 0 0 0 12px transparent;
+  color: #212121;
+  border-radius: 12px;
+}
+
+.animated-button:hover .arr-1 {
+  right: -25%;
+}
+
+.animated-button:hover .arr-2 {
+  left: 16px;
+}
+
+.animated-button:hover .text {
+  transform: translateX(12px);
+}
+
+.animated-button:hover svg {
+  fill: #212121;
+}
+
+.animated-button:active {
+  scale: 0.95;
+  box-shadow: 0 0 0 4px greenyellow;
+}
+
+.animated-button:hover .circle {
+  width: 220px;
+  height: 220px;
+  opacity: 1;
 }
 
 #game-container {
@@ -150,7 +366,7 @@ h3 {
   height: 80px;
 }
 
-#controls {
+#home {
   margin-top: 50px;
 }
 
@@ -158,12 +374,12 @@ h3 {
   all: unset; /* 全てのデフォルトスタイルをリセット */
 }
 
-i {
+#home i {
   cursor: pointer;
   transition: all 0.4s ease;
 }
 
-i:hover {
+#home i:hover {
   opacity: 0.5;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -47,8 +47,8 @@ h3 {
 
 .button-container {
   position: absolute;
-  top: 100px;
-  right: 300px;
+  top: 10%;
+  right: 20%;
 }
 
 #control-btn {

--- a/index.html
+++ b/index.html
@@ -8,25 +8,70 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 <body>
+    <!-- ?アイコンのボタン -->
+    <div class="button-container">
+        <div id="control-btn">
+            <i class="fas fa-question-circle"></i>
+        </div>
+    </div>
+
+    <div id="controlsModal" class="modal">
+        <div class="modal-content">
+            <span class="close-btn">&times;</span>
+            <h2 class="controls-title">HOW TO PLAY</h2>
+            <div class="control-item">
+                <div class="control-icon">← →</div>
+                <div class="control-description">Move left / right</div>
+            </div>
+            <div class="control-item">
+                <div class="control-icon">↓</div>
+                <div class="control-description">Soft drop</div>
+            </div>
+            <div class="control-item">
+                <div class="control-icon">↑</div>
+                <div class="control-description">Rotate clockwise</div>
+            </div>
+            <div class="control-item">
+                <div class="control-icon">X</div>
+                <div class="control-description">Rotate clockwise</div>
+            </div>
+            <div class="control-item">
+                <div class="control-icon">Z</div>
+                <div class="control-description">Rotate counterclockwise</div>
+            </div>
+            <div class="control-item">
+                <div class="control-icon">C</div>
+                <div class="control-description">Hold piece</div>
+            </div>
+            <div class="control-item">
+                <div class="control-icon">␣</div>
+                <div class="control-description">Hard drop</div>
+            </div>
+        </div>
+    </div>
+
     <div id="space-background">
-        <div class="planet"></div> <!-- 背景に使用する球体デザイン -->
-        <div class="stars"></div>
+        <div class="planet"> <!-- 背景に使用する球体デザイン -->
+        </div>
+        <div class="star"></div>
     </div>
 
     <div id="start-screen">
-        <h1>テトリス</h1>
-        <button id="start-button">ゲーム開始</button>
-        <div id="key-rule">
-            <h2>操作方法</h2>
-            <ul>
-                <li>← → : 左右移動</li>
-                <li>↓ : 落下加速 (ソフトドロップ)</li>
-                <li>↑ or X: 時計回りに回転</li>
-                <li>Z : 反時計回りに回転</li>
-                <li>スペース : ハードドロップ</li>
-                <li>C or shift: ホールド</li>
-            </ul>
-        </div>
+        <h1 class="tetris-title" data-text="Tetris">Tetris</h1>
+        <button id="start-button" class="animated-button">
+          <svg viewBox="0 0 24 24" class="arr-2" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M16.1716 10.9999L10.8076 5.63589L12.2218 4.22168L20 11.9999L12.2218 19.778L10.8076 18.3638L16.1716 12.9999H4V10.9999H16.1716Z"
+            ></path>
+          </svg>
+          <span class="text">PLAY NOW </span>
+          <span class="circle"></span>
+          <svg viewBox="0 0 24 24" class="arr-1" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M16.1716 10.9999L10.8076 5.63589L12.2218 4.22168L20 11.9999L12.2218 19.778L10.8076 18.3638L16.1716 12.9999H4V10.9999H16.1716Z"
+            ></path>
+          </svg>
+        </button>
     </div>
 
 
@@ -50,7 +95,7 @@
                             <p id="line">0</p>
                         </div>
                     </div>
-                    <div id="controls">
+                    <div id="home">
                        <button id="home-button"><i class="fa-solid fa-house fa-2x"></i></button>
                     </div>
                 </div>
@@ -70,6 +115,7 @@
             </div>
         </div>   
     </div>
+    
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/js/game.js
+++ b/js/game.js
@@ -8,6 +8,7 @@ import { checkGameOver, handleGameOver, updateScore, initScore, initLines, initL
 export let animationId;
 let lastDropTime = 0;
 let nextTetriminos = [];
+let isPaused = false; // ゲームを停止用の変数
 
 export function initGame() {
     initField();
@@ -30,6 +31,8 @@ export async function gameLoop(currentTime) {
     drawPlayScreen();
     drawHoldTetrimino(holdTetrimino);
     drawNextTetriminos(nextTetriminos);
+
+    if (isPaused) return;
     
     if (currentTetrimino === null) {
         console.log('Adding next tetrimino');
@@ -48,6 +51,17 @@ export async function gameLoop(currentTime) {
     }
     
     animationId = requestAnimationFrame(gameLoop);
+}
+
+
+export function pauseGame() {
+    isPaused = true;
+    cancelAnimationFrame(animationId);
+}
+
+export function resumeGame() {
+    isPaused = false;
+    requestAnimationFrame(gameLoop);
 }
 
 // アニメーションを停止する関数

--- a/js/gameManager.js
+++ b/js/gameManager.js
@@ -1,3 +1,5 @@
+import { pauseGame, resumeGame } from './game.js';
+
 // ゲームスタート、ゲームやり直しの関数
 export function setupGameScreens(startGameFunction, stopGameFunction,) {
     const startScreen = document.getElementById('start-screen');
@@ -34,11 +36,20 @@ function hideControls() {
 }
 
 export function setupModalEventListeners() {
-    controlBtn.addEventListener('click', showControls);
-    closeBtn.addEventListener('click', hideControls);
+    controlBtn.addEventListener('click', () => {
+        showControls();
+        pauseGame();  // ゲームを一時停止
+    });
+
+    closeBtn.addEventListener('click', () => {
+        hideControls();
+        resumeGame();  // ゲームを再開
+    });
+
     window.addEventListener('click', (event) => {
         if (event.target === modal) {
-        hideControls();
+            hideControls();
+            resumeGame();  // ゲームを再開
         }
     });
 }

--- a/js/gameManager.js
+++ b/js/gameManager.js
@@ -19,3 +19,26 @@ export function setupGameScreens(startGameFunction, stopGameFunction,) {
         stopGameFunction(); // ゲームを停止・リセット
     });
 }
+
+// モーダルウィンドウの表示関数
+const controlBtn = document.querySelector('#control-btn');
+const modal = document.querySelector('#controlsModal');
+const closeBtn = document.querySelector('.close-btn');
+
+function showControls() {
+    modal.style.display = 'block';
+}
+
+function hideControls() {
+    modal.style.display = 'none';
+}
+
+export function setupModalEventListeners() {
+    controlBtn.addEventListener('click', showControls);
+    closeBtn.addEventListener('click', hideControls);
+    window.addEventListener('click', (event) => {
+        if (event.target === modal) {
+        hideControls();
+        }
+    });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 import { initGame, gameLoop, stopGameLoop } from './game.js';
 import { initInput } from './input.js';
-import { setupGameScreens } from './gameManager.js';
+import { setupGameScreens,setupModalEventListeners } from './gameManager.js';
 
 // スタートボタンを押すことで実行される関数の集まり。
 function startGame() {
@@ -10,7 +10,8 @@ function startGame() {
 }
 
 function init() {
-    setupGameScreens(startGame, stopGameLoop,);
+    setupGameScreens(startGame, stopGameLoop);
+    setupModalEventListeners();
 }
 
 init();


### PR DESCRIPTION
## 概要
スタート画面のタイトル、PLAYボタンのスタイリング、モーダルウィンドウの追加。
ゲーム画面でモーダルウィンドウを開いた際に、ゲームが一時停止する機能を実装。

## 変更内容

- スタート画面のタイトルのスタイリング
- スタート画面のボタンの調整
- 画面右上にアイコンを追加。これはスタート、ゲーム画面両方で常時表示される。アイコンをクリックすることでモーダルウィンドウが表示され、テトリスの操作方法を閲覧できる。
- `gameManager.js`にモーダルウィンドウを表示させる関数を追加。
- ゲーム画面でウィンドウを開いた際に、ゲームが一時停止する関数を`game.js`に追加。

## テスト結果
![スクリーンショット 2024-09-28 0 35 58](https://github.com/user-attachments/assets/e7eb74ae-6745-48d7-96d9-731e6dd9b276)

![スクリーンショット 2024-09-28 0 36 12](https://github.com/user-attachments/assets/1b7332c7-3cf2-4509-a83b-93cb416b2bb0)

![スクリーンショット 2024-09-28 0 36 33](https://github.com/user-attachments/assets/32db2ce6-4ccc-4838-bac1-e7b7fbe7a05d)


## レビューポイント
<!-- レビュアーに特に見てほしい点があれば記述 -->

## 関連Issue
#48 